### PR TITLE
Server name indication is a big deal

### DIFF
--- a/draft-ietf-tls-sslv3-diediedie.md
+++ b/draft-ietf-tls-sslv3-diediedie.md
@@ -48,6 +48,7 @@ informative:
   RFC3174:
   RFC4492:
   RFC5077:
+  RFC6066:
   RFC6176:
   RFC6347:
   RFC7301:
@@ -211,7 +212,8 @@ prominent:
 
 * A datagram mode of operation, DTLS {{RFC6347}}.
 
-* Application layer protocol negotiation {{RFC7301}}.
+* Server name indication {{RFC6066}} and other extensions, such as application
+  layer protocol negotiation {{RFC7301}}.
 
 
 # IANA Considerations

--- a/draft-ietf-tls-sslv3-diediedie.md
+++ b/draft-ietf-tls-sslv3-diediedie.md
@@ -41,6 +41,7 @@ normative:
   RFC5246:
   RFC6101:
   RFC7366:
+  RFC7465:
 
 informative:
   RFC1321:
@@ -50,7 +51,6 @@ informative:
   RFC6176:
   RFC6347:
   RFC7301:
-  RFC7465:
   FIPS180-2:
     title: NIST FIPS 180-2, Secure Hash Standard
     author:


### PR DESCRIPTION
Apparently.  Turns out that it depends on perspective as to which extension is most important, but this should be fine.
